### PR TITLE
Allow zeroes in second digit of hex

### DIFF
--- a/keyRecover.py
+++ b/keyRecover.py
@@ -51,6 +51,6 @@ for A in range(keyLength):
 
 # Get rid of first 24-bit initialization vector.
 userInput = key[3:]
-result = [format(key, 'x') for key in userInput]
+result = ["{:02x}".format(key) for key in userInput]
 rawkey = ''.join(result).upper()
 print(rawkey)


### PR DESCRIPTION
If it gets 0x07 it writes it as just 7 in the key which is invalid hex. Now it writes 07.